### PR TITLE
Correction of newline print statement in fasd_cd

### DIFF
--- a/fasd
+++ b/fasd
@@ -92,7 +92,7 @@ fasd_cd() {
   else
     local _fasd_ret="\$(fasd -e 'printf %s' "\$@")"
     [ -z "\$_fasd_ret" ] && return
-    [ -d "\$_fasd_ret" ] && cd "\$_fasd_ret" || printf %s\\n "\$_fasd_ret"
+    [ -d "\$_fasd_ret" ] && cd "\$_fasd_ret" || printf '%s\\n' "\$_fasd_ret"
   fi
 }
 alias z='fasd_cd -d'


### PR DESCRIPTION
If you used fasd_cd without giving a directory, then fasd_cd would print
out the input name and add a 'n' to the name instead of printing a
newline. At least within bash.
